### PR TITLE
JProCompatible Version (Dont Merge)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.dockfx</groupId>
     <artifactId>dockfx</artifactId>
     <packaging>jar</packaging>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.1-SNAPSHOT</version>
     <name>DockFX</name>
     <url>https://github.com/RobertBColton/DockFX.git</url>
 
@@ -16,10 +16,22 @@
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fileExtensions>java, properties, xml</fileExtensions>
+        <jpro.version>2020.1.1-SNAPSHOT</jpro.version>
+        <javafx.version>15</javafx.version>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.sandec.jpro</groupId>
+                <artifactId>jpro-maven-plugin</artifactId>
+                <version>${jpro.version}</version>
+                <configuration>
+                    <visible>false</visible>
+                    <mainClassName>org.dockfx.demo.DockFX</mainClassName>
+                    <openingPath>/</openingPath>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -71,8 +83,76 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
+
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>bintray-sandec-repo</id>
+            <name>sandec-repo</name>
+            <url>https://api.bintray.com/maven/sandec/repo/dockfx/;publish=1</url>
+        </repository>
+    </distributionManagement>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jpro - sandec repository</id>
+            <url>https://sandec.bintray.com/repo</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <repositories>
+        <repository>
+            <id>jpro - sandec repository</id>
+            <url>https://sandec.bintray.com/repo</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-web</artifactId>
+            <version>${javafx.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>${javafx.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-media</artifactId>
+            <version>${javafx.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
     <reporting>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.dockfx</groupId>
+    <groupId>de.sandec</groupId>
     <artifactId>dockfx</artifactId>
     <packaging>jar</packaging>
-    <version>0.4.1-SNAPSHOT</version>
+    <version>0.4.1</version>
     <name>DockFX</name>
     <url>https://github.com/RobertBColton/DockFX.git</url>
 

--- a/src/main/java/org/dockfx/DockNode.java
+++ b/src/main/java/org/dockfx/DockNode.java
@@ -105,6 +105,18 @@ public class DockNode extends VBox implements EventHandler<MouseEvent> {
         borderPane.pseudoClassStateChanged(MAXIMIZED_PSEUDO_CLASS, get());
       }
 
+      Stage rootWindow = (Stage) stage;
+      while(rootWindow.getOwner() != null) {
+        rootWindow = (Stage) rootWindow.getOwner();
+      }
+      if(this.get()) {
+        stage.setX(rootWindow.getX());
+        stage.setY(rootWindow.getY());
+        stage.setWidth(rootWindow.getWidth());
+        stage.setHeight(rootWindow.getHeight());
+      }
+
+      /*
       stage.setMaximized(get());
 
       // TODO: This is a work around to fill the screen bounds and not overlap the task bar when 
@@ -123,7 +135,7 @@ public class DockNode extends VBox implements EventHandler<MouseEvent> {
 
         stage.setWidth(bounds.getWidth());
         stage.setHeight(bounds.getHeight());
-      }
+      }*/
     }
 
     @Override

--- a/src/main/java/org/dockfx/DockTitleBar.java
+++ b/src/main/java/org/dockfx/DockTitleBar.java
@@ -409,7 +409,7 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
         }
       };
 
-      this.pickEventTarget(new Point2D(event.getScreenX(), event.getScreenY()), eventTask, null, dockNode.getStage());
+      this.pickEventTarget(new Point2D(event.getScreenX(), event.getScreenY()), eventTask, null, (Stage) this.getScene().getWindow());
 
       dragNodes.clear();
 

--- a/src/main/java/org/dockfx/DockTitleBar.java
+++ b/src/main/java/org/dockfx/DockTitleBar.java
@@ -221,16 +221,20 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
    * @param eventTask The event task to be run when the event target is found.
    * @param explicit The explicit event to be fired on the stage root when no event target is found.
    */
-  private void pickEventTarget(Point2D location, EventTask eventTask, Event explicit) {
+  private void pickEventTarget(Point2D location, EventTask eventTask, Event explicit, Stage context) {
     // RFE for public scene graph traversal API filed but closed:
     // https://bugs.openjdk.java.net/browse/JDK-8133331
 
-    List<DockPane> dockPanes = DockPane.dockPanes;
+    List<DockPane> dockPanes = DockPane.getDockPanes(context);
 
     // fire the dock over event for the active stages
     for (DockPane dockPane : dockPanes) {
+      if(dockPane.getScene() == null) continue;
       Window window = dockPane.getScene().getWindow();
       if (!(window instanceof Stage)) continue;
+      if (!window.isShowing()) {
+        continue;
+      }
       Stage targetStage = (Stage) window;
 
       // obviously this title bar does not need to receive its own events
@@ -396,7 +400,7 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
       };
 
       this.pickEventTarget(new Point2D(event.getScreenX(), event.getScreenY()), eventTask,
-          dockExitEvent);
+          dockExitEvent, stage);
     } else if (event.getEventType() == MouseEvent.MOUSE_RELEASED) {
       dragging = false;
 
@@ -415,7 +419,7 @@ public class DockTitleBar extends HBox implements EventHandler<MouseEvent> {
         }
       };
 
-      this.pickEventTarget(new Point2D(event.getScreenX(), event.getScreenY()), eventTask, null);
+      this.pickEventTarget(new Point2D(event.getScreenX(), event.getScreenY()), eventTask, null, dockNode.getStage());
 
       dragNodes.clear();
 

--- a/src/main/java/org/dockfx/demo/DockFX.java
+++ b/src/main/java/org/dockfx/demo/DockFX.java
@@ -26,23 +26,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Random;
 
+import javafx.scene.control.*;
 import org.dockfx.DockNode;
 import org.dockfx.DockPane;
 import org.dockfx.DockPos;
 
 import javafx.application.Application;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.control.Menu;
-import javafx.scene.control.MenuBar;
-import javafx.scene.control.Separator;
-import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.scene.control.ToolBar;
-import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeView;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Priority;
@@ -66,15 +56,10 @@ public class DockFX extends Application {
 
     // create a default test node for the center of the dock area
     TabPane tabs = new TabPane();
-    HTMLEditor htmlEditor = new HTMLEditor();
-    try {
-      htmlEditor.setHtmlText(new String(Files.readAllBytes(Paths.get("readme.html"))));
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+
 
     // empty tabs ensure that dock node has its own background color when floating
-    tabs.getTabs().addAll(new Tab("Tab 1", htmlEditor), new Tab("Tab 2"), new Tab("Tab 3"));
+    tabs.getTabs().addAll(new Tab("Tab 1", new Label("Coontent!")), new Tab("Tab 2"), new Tab("Tab 3"));
 
     TableView<String> tableView = new TableView<String>();
     // this is why @SupressWarnings is used above


### PR DESCRIPTION
This is probably not a real pull request, but it serves the purpose to let the maintainer and interested persons know that this version exists.

I've created a version of DockFX which is compatible with JPro.
It also fixes a memory leak with the never-ending animation and requires at least JavaFX11.
It's 100% Sourcecode compatible.

online demo: https://www.javafx-ensemble.com/?page=sample/dockfx/org.dockfx.demo.DockFX
github-repositroy: https://github.com/FlorianKirmaier/DockFX
maven-repository: https://bintray.com/sandec/repo/dockfx/0.4.1 (I've changed the group to avoid conflicts)

It could be integrated back to the main-repository by using a lot of ifs.